### PR TITLE
Fix various issues

### DIFF
--- a/ot/baseOT.h
+++ b/ot/baseOT.h
@@ -29,7 +29,7 @@ public:
 	}
 	;
 
-	~BaseOT() { delete m_cPKCrypto; };
+	virtual ~BaseOT() { delete m_cPKCrypto; };
 
 	virtual void Sender(uint32_t nSndVals, uint32_t nOTs, channel* chan, uint8_t* ret) = 0;
 	virtual void Receiver(uint32_t nSndVals, uint32_t uint32_t, CBitVector* choices, channel* chan, uint8_t* ret) = 0;

--- a/ot/nnob-ot-ext-rec.cpp
+++ b/ot/nnob-ot-ext-rec.cpp
@@ -275,7 +275,7 @@ void NNOBOTExtRec::ComputeOWF(queue<nnob_rcv_check_t>* check_buf_q, channel* che
 			assert((*sender_permchoicebitptr) == 0 || (*sender_permchoicebitptr == 1));
 
 			tmp.SetXOR(kaptr, kbptr, 0, bufrowbytelen);
-			if((*sender_permchoicebitptr == 1)) {
+			if(*sender_permchoicebitptr == 1) {
 				tmp.XORBytesReverse(receiver_choicebits, 0, checkbytelen);
 			}
 

--- a/util/cbitvector.cpp
+++ b/util/cbitvector.cpp
@@ -181,7 +181,7 @@ void CBitVector::GetBits(BYTE* p, int pos, int len) {
 	int remlen = len & 0x07;
 	if (remlen) {
 		if (remlen <= uppermask) {
-			p[i] = ((m_pBits[posctr] & (((1 << remlen) - 1 << lowermask))) >> lowermask) & 0xFF;
+			p[i] = ((m_pBits[posctr] & ((((1 << remlen) - 1) << lowermask))) >> lowermask) & 0xFF;
 		} else {
 			p[i] = ((m_pBits[posctr] & GET_BIT_POSITIONS[lowermask]) >> lowermask) & 0xFF;
 			p[i] |= (m_pBits[posctr + 1] & (((1 << (remlen - uppermask)) - 1))) << uppermask;

--- a/util/crypto/crypto.cpp
+++ b/util/crypto/crypto.cpp
@@ -387,18 +387,27 @@ void sha512_hash(uint8_t* resbuf, uint32_t noutbytes, uint8_t* inbuf, uint32_t n
 
 //Read random bytes from /dev/random - copied from stackoverflow (post by zneak)
 void gen_secure_random(uint8_t* dest, uint32_t nbytes) {
-	int32_t randomData = open("/dev/random", O_RDONLY);
-	uint32_t bytectr = 0;
+	int fd = open("/dev/random", O_RDONLY);
+	if (fd < 0)
+	{
+		cerr << "Unable to open /dev/random, exiting" << endl;
+		exit(0);
+	}
+	size_t bytectr = 0;
 	while (bytectr < nbytes) {
-		uint32_t result = read(randomData, dest + bytectr, nbytes - bytectr);
+		ssize_t result = read(fd, dest + bytectr, nbytes - bytectr);
 		if (result < 0) {
 			cerr << "Unable to read from /dev/random, exiting" << endl;
 			exit(0);
 		}
-		bytectr += result;
+		bytectr += static_cast<size_t>(result);
 	}
-	close(randomData);
+	if (close(fd) < 0)
+	{
+		cerr << "Unable to close /dev/random" << endl;
+	}
 }
+
 
 seclvl get_sec_lvl(uint32_t symsecbits) {
 	if (symsecbits == ST.symbits)


### PR DESCRIPTION
This fixes a few issues clang is reporting during compilation.

Make destructor of abstract class virtual:
```
nnob-ot-ext-rec.cpp:323:3: warning: delete called on 'BaseOT' that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
                delete m_cBaseOT;
                ^
```


Remove extra pair of parentheses:
```
nnob-ot-ext-rec.cpp:278:33: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
                        if((*sender_permchoicebitptr == 1)) {
                            ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
nnob-ot-ext-rec.cpp:278:33: note: remove extraneous parentheses around the comparison to silence this warning
                        if((*sender_permchoicebitptr == 1)) {
                           ~                         ^   ~
nnob-ot-ext-rec.cpp:278:33: note: use '=' to turn this equality comparison into an assignment
                        if((*sender_permchoicebitptr == 1)) {
                                                     ^~
                                                     =
```


Add parentheses to clarify operator precedence (see encryptogroup/ABY#18)
```
cbitvector.cpp:184:47: warning: operator '<<' has lower precedence than '-'; '-' will be evaluated first [-Wshift-op-parentheses]
                        p[i] = ((m_pBits[posctr] & (((1 << remlen) - 1 << lowermask))) >> lowermask) & 0xFF;
                                                     ~~~~~~~~~~~~~~^~~ ~~
cbitvector.cpp:184:47: note: place parentheses around the '-' expression to silence this warning
                        p[i] = ((m_pBits[posctr] & (((1 << remlen) - 1 << lowermask))) >> lowermask) & 0xFF;
                                                                   ^
                                                     (                )
```

Check signed return value of read (see encryptogroup/ABY#17)
```
crypto.cpp:394:14: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
                if (result < 0) {
                    ~~~~~~ ^ ~
```