### PR TITLE
Fix memory errors

### DIFF
--- a/ot/alsz-ot-ext-snd.cpp
+++ b/ot/alsz-ot-ext-snd.cpp
@@ -413,7 +413,7 @@ BOOL ALSZOTExtSnd::CheckConsistency(queue<alsz_snd_check_t>* check_buf_q, channe
 	free(check_buf.perm);
 	free(check_buf.rcv_chk_buf);
 	free(check_buf.seed_chk_buf);
-	delete(check_buf.choices);
+	// do not delete(check_buf.choices): all choices vectors are freed in ~OTExtSnd()
 
 	return TRUE;
 }

--- a/ot/iknp-ot-ext-rec.h
+++ b/ot/iknp-ot-ext-rec.h
@@ -28,7 +28,7 @@ public:
 	;
 
 
-	~IKNPOTExtRec() {}	;
+	virtual ~IKNPOTExtRec() {}	;
 
 	BOOL receiver_routine(uint32_t threadid, uint64_t numOTs);
 	void ComputeBaseOTs(field_type ftype);

--- a/ot/iknp-ot-ext-snd.cpp
+++ b/ot/iknp-ot-ext-snd.cpp
@@ -124,18 +124,8 @@ BOOL IKNPOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 	chan->synchronize_end();
 
 	Q.delCBitVector();
-	for (uint32_t u = 0; u < m_nSndVals; u++)
-		seedbuf[u].delCBitVector();
-#ifndef ABY_OT
 	delete[] seedbuf;
-#endif
-
-	for (uint32_t i = 0; i < numsndvals; i++)
-		vSnd[i].delCBitVector();
-#ifndef ABY_OT
-	if (numsndvals > 0)
-		delete[] vSnd;
-#endif
+	delete[] vSnd;
 
 	if(m_eSndOTFlav==Snd_GC_OT)
 		freeRndMatrix(rndmat, m_nBaseOTs);

--- a/ot/iknp-ot-ext-snd.h
+++ b/ot/iknp-ot-ext-snd.h
@@ -19,7 +19,7 @@ public:
 	;
 
 
-	~IKNPOTExtSnd() {	};
+	virtual ~IKNPOTExtSnd() {	};
 
 	BOOL sender_routine(uint32_t threadid, uint64_t numOTs);
 	void ComputeBaseOTs(field_type ftype);

--- a/ot/kk-ot-ext-rec.h
+++ b/ot/kk-ot-ext-rec.h
@@ -30,7 +30,7 @@ public:
 	;
 
 
-	~KKOTExtRec() {
+	virtual ~KKOTExtRec() {
 		//TODO
 		//free(m_vKeySeedMtx);
 	}

--- a/ot/kk-ot-ext-snd.h
+++ b/ot/kk-ot-ext-snd.h
@@ -27,7 +27,7 @@ public:
 	;
 
 
-	~KKOTExtSnd() {
+	virtual ~KKOTExtSnd() {
 	}
 	;
 

--- a/ot/kk-ot-ext.h
+++ b/ot/kk-ot-ext.h
@@ -11,6 +11,14 @@
 #define KK_OT_EXT_H_
 
 class KKOTExt {
+public:
+	virtual ~KKOTExt() {
+		for(size_t i = 0; i < m_nCodeWordBits; i++) {
+			free(m_vCodeWords[i]);
+		}
+		free(m_vCodeWords);
+	}
+
 protected:
 	void set_internal_sndvals(uint32_t ext_sndvals, uint32_t bitlen) {
 		uint32_t min_int;

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -25,6 +25,7 @@ public:
 			for(uint32_t j = 0; j < m_nBaseOTs * nsndvals; j++) {
 				m_cCrypt->clean_aes_key(&m_tBaseOTKeys[i][j]);
 			}
+			free(m_tBaseOTKeys[i]);
 		}
 	};
 	BOOL receive(uint64_t numOTs, uint64_t bitlength, uint64_t nsndvals, CBitVector* choices, CBitVector* ret,

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -16,7 +16,14 @@ class OTExtRec : public OTExt {
 public:
 
 	OTExtRec(){};
-	virtual ~OTExtRec(){};
+	virtual ~OTExtRec(){
+		uint32_t nsndvals = 2;
+		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
+			for(uint32_t j = 0; j < m_nBaseOTs * nsndvals; j++) {
+				m_cCrypt->clean_aes_key(&m_tBaseOTKeys[i][j]);
+			}
+		}
+	};
 	BOOL receive(uint64_t numOTs, uint64_t bitlength, uint64_t nsndvals, CBitVector* choices, CBitVector* ret,
 			snd_ot_flavor stype, rec_ot_flavor rtype, uint32_t numThreads, MaskingFunction* maskfct);
 

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -17,6 +17,9 @@ public:
 
 	OTExtRec(){};
 	virtual ~OTExtRec(){
+		// TODO: nsndvals is currently hardcoeded in OTExtRec::ComputePKBaseOTs()
+		// maybe add it as a private attribute to class OTExt and move the
+		// following loop to its destructor?
 		uint32_t nsndvals = 2;
 		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
 			for(uint32_t j = 0; j < m_nBaseOTs * nsndvals; j++) {

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -13,7 +13,7 @@
 class OTExtSnd : public OTExt {
 
 public:
-	OTExtSnd() {};
+	OTExtSnd() : m_vValues(nullptr) {};
 
 	virtual ~OTExtSnd() {
 		//for(uint32_t i = 0; i < m_tBaseOTChoices.size(); i++)

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -13,7 +13,7 @@
 class OTExtSnd : public OTExt {
 
 public:
-	OTExtSnd() : m_vValues(nullptr) {};
+	OTExtSnd() {};
 
 	virtual ~OTExtSnd() {
 		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {
@@ -27,7 +27,7 @@ public:
 			}
 			free(m_tBaseOTKeys[i]);
 		}
-		free(m_vValues);
+		// do not free(m_vValues), since it is passed from the outside to send()
 	};
 
 	BOOL send(uint64_t numOTs, uint64_t bitlength, uint64_t nsndvals, CBitVector** X, snd_ot_flavor stype,

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -19,7 +19,11 @@ public:
 		//for(uint32_t i = 0; i < m_tBaseOTChoices.size(); i++)
 		//	m_tBaseOTChoices[i]->delCBitVector();
 		m_tBaseOTChoices.clear();
-
+		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
+			for(uint32_t j = 0; j < m_nBaseOTs; j++) {
+				m_cCrypt->clean_aes_key(&m_tBaseOTKeys[i][j]);
+			}
+		}
 		free(m_vValues);
 	};
 

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -19,10 +19,13 @@ public:
 		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {
 			delete m_tBaseOTChoices[i];
 		}
+		// TODO: This could be done in OTExt destructor;
+		// see also comment in OTExtSnd destructor
 		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
 			for(uint32_t j = 0; j < m_nBaseOTs; j++) {
 				m_cCrypt->clean_aes_key(&m_tBaseOTKeys[i][j]);
 			}
+			free(m_tBaseOTKeys[i]);
 		}
 		free(m_vValues);
 	};

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -16,9 +16,9 @@ public:
 	OTExtSnd() : m_vValues(nullptr) {};
 
 	virtual ~OTExtSnd() {
-		//for(uint32_t i = 0; i < m_tBaseOTChoices.size(); i++)
-		//	m_tBaseOTChoices[i]->delCBitVector();
-		m_tBaseOTChoices.clear();
+		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {
+			delete m_tBaseOTChoices[i];
+		}
 		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
 			for(uint32_t j = 0; j < m_nBaseOTs; j++) {
 				m_cCrypt->clean_aes_key(&m_tBaseOTKeys[i][j]);

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -103,10 +103,6 @@ class OTExt {
 public:
 	OTExt(){};
 	virtual ~OTExt() {
-		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
-			free(m_tBaseOTKeys[i]);
-		}
-		m_tBaseOTKeys.clear();
 #ifdef FIXED_KEY_AES_HASHING
 		free(m_kCRFKey);
 #endif

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -103,8 +103,9 @@ class OTExt {
 public:
 	OTExt(){};
 	virtual ~OTExt() {
-		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++)
+		for(uint32_t i = 0; i < m_tBaseOTKeys.size(); i++) {
 			free(m_tBaseOTKeys[i]);
+		}
 		m_tBaseOTKeys.clear();
 #ifdef FIXED_KEY_AES_HASHING
 		free(m_kCRFKey);

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -104,6 +104,7 @@ public:
 	OTExt(){};
 	virtual ~OTExt() {
 #ifdef FIXED_KEY_AES_HASHING
+		m_cCrypt->clean_aes_key(m_kCRFKey);
 		free(m_kCRFKey);
 #endif
 	};

--- a/util/rcvthread.h
+++ b/util/rcvthread.h
@@ -13,9 +13,15 @@
 #include "socket.h"
 #include "thread.h"
 
+typedef struct {
+	uint8_t *buf;
+	uint64_t rcvbytes;
+} rcv_ctx;
+
 //A receive task listens to a particular id and writes incoming data on that id into rcv_buf and triggers event
 struct rcv_task {
-	std::queue<uint8_t*> *rcv_buf;
+	std::queue<rcv_ctx*>* rcv_buf;
+	//std::queue<uint64_t> rcvbytes;
 	CEvent* rcv_event;
 	CEvent* fin_event;
 	BOOL inuse;
@@ -30,21 +36,26 @@ public:
 		rcvlock = new CLock();
 		listeners = (rcv_task*) calloc(MAX_NUM_COMM_CHANNELS, sizeof(rcv_task));
 		for(uint32_t i = 0; i < MAX_NUM_COMM_CHANNELS; i++) {
-			listeners[i].rcv_buf = new queue<uint8_t*>;
+			listeners[i].rcv_buf = new queue<rcv_ctx*>;
 		}
 		listeners[ADMIN_CHANNEL].inuse = true;
 	}
 	;
 	~RcvThread() {
-		this->Kill();
-		delete rcvlock;
+		this->Wait();
+		for(uint32_t i = 0; i < MAX_NUM_COMM_CHANNELS; i++) {
+			flush_queue(i);
+			delete listeners[i].rcv_buf;
+		}
 		free(listeners);
+		delete rcvlock;
 	}
 	;
 
 	void flush_queue(uint8_t channelid) {
 		while(!listeners[channelid].rcv_buf->empty()) {
-			uint8_t* tmp = listeners[channelid].rcv_buf->front();
+			rcv_ctx* tmp = listeners[channelid].rcv_buf->front();
+			free(tmp->buf);
 			free(tmp);
 			listeners[channelid].rcv_buf->pop();
 		}
@@ -65,7 +76,7 @@ public:
 		rcvlock->Unlock();
 
 	}
-	queue<uint8_t*>* add_listener(uint8_t channelid, CEvent* rcv_event, CEvent* fin_event) {
+	queue<rcv_ctx*>* add_listener(uint8_t channelid, CEvent* rcv_event, CEvent* fin_event) {
 		rcvlock->Lock();
 #ifdef DEBUG_RECEIVE_THREAD
 		cout << "Registering listener on channel " << (uint32_t) channelid << endl;
@@ -128,10 +139,13 @@ public:
 				if(rcvbytelen == 0) {
 					remove_listener(channelid);
 				} else {
-					tmprcvbuf = (uint8_t*) malloc(rcvbytelen);
-					mysock->Receive(tmprcvbuf, rcvbytelen);
+					rcv_ctx* rcv_buf = (rcv_ctx*) malloc(sizeof(rcv_ctx));
+					rcv_buf->buf = (uint8_t*) malloc(rcvbytelen);
+					rcv_buf->rcvbytes = rcvbytelen;
 
-					listeners[channelid].rcv_buf->push(tmprcvbuf);
+					mysock->Receive(rcv_buf->buf, rcvbytelen);
+					listeners[channelid].rcv_buf->push(rcv_buf);
+
 					if(listeners[channelid].inuse)
 						listeners[channelid].rcv_event->Set();
 				}

--- a/util/rcvthread.h
+++ b/util/rcvthread.h
@@ -122,7 +122,6 @@ public:
 #ifdef DEBUG_RECEIVE_THREAD
 					cout << "Receiver thread is being killed" << endl;
 #endif
-					m_bRunning = false;
 					return;//continue;
 				}
 

--- a/util/thread.h
+++ b/util/thread.h
@@ -1,15 +1,15 @@
 // thread.h by sgchoi@cs.umd.edu
 
-#ifndef __THREAD_H__BY_SGCHOI  
-#define __THREAD_H__BY_SGCHOI 
+#ifndef __THREAD_H__BY_SGCHOI
+#define __THREAD_H__BY_SGCHOI
 
 #include "typedefs.h"
 
-#ifdef WIN32 
- 
+#ifdef WIN32
+
 #include <process.h>
 
-class CEvent  
+class CEvent
 {
 // Constructor
 public:
@@ -19,8 +19,8 @@ public:
 	}
 
 	~CEvent()
-	{ 
-		CloseHandle(m_hHandle);	
+	{
+		CloseHandle(m_hHandle);
 	}
 
 // Operations
@@ -37,7 +37,7 @@ private:
 /////////////////////////////////////////////////////////////////////////////
 // CLock
 
-	
+
 // Operations
 class CLock
 {
@@ -49,9 +49,9 @@ public:
 public:
 	void Lock(){  EnterCriticalSection(&m_cs);  }
 	void Unlock(){ LeaveCriticalSection(&m_cs); }
-	 
+
 private:
-	CRITICAL_SECTION m_cs;  
+	CRITICAL_SECTION m_cs;
 };
 
 class CThread
@@ -67,13 +67,14 @@ public:
 		m_hHandle = CreateThread(0, 0, ThreadMainHandler, this,0,0);
 		if( m_hHandle == NULL )
 			m_bRunning = FALSE;
-	
+
 		return m_bRunning;
 	}
 
     BOOL Wait()
     {
 		if( !m_bRunning ) return TRUE;
+        m_bRunning = FALSE;
 		return WaitForSingleObject(m_hHandle, INFINITE) == WAIT_OBJECT_0;
     }
 
@@ -98,7 +99,6 @@ protected:
     {
 		CThread* pThis = (CThread*) p;
 		pThis->ThreadMain();
-		pThis->m_bRunning = FALSE;
 		return 0;
 	    }
 
@@ -106,9 +106,9 @@ protected:
  	BOOL	m_bRunning;
 	HANDLE	m_hHandle;
 };
- 
 
-#else // NOT WIN32 
+
+#else // NOT WIN32
 #include <pthread.h>
 class CThread
 {
@@ -119,7 +119,7 @@ public:
 public:
     BOOL Start()
 	{
-		m_bRunning = !pthread_create(&m_pThread, NULL, 
+		m_bRunning = !pthread_create(&m_pThread, NULL,
 						ThreadMainHandler, (void*) this);
 		return m_bRunning;
 	}
@@ -127,6 +127,7 @@ public:
     BOOL Wait()
     {
 		if( !m_bRunning ) return TRUE;
+        m_bRunning = FALSE;
 		return pthread_join(m_pThread, NULL)==0;
     }
 
@@ -148,7 +149,6 @@ protected:
     {
 		CThread* pThis = (CThread*) p;
 		pThis->ThreadMain();
-		pThis->m_bRunning = FALSE;
 		return 0;
     }
 
@@ -167,15 +167,15 @@ public:
 
 public:
 	void Lock(){ pthread_mutex_lock(&m_mtx);}
-	void Unlock(){ pthread_mutex_unlock(&m_mtx); } 
-	 
+	void Unlock(){ pthread_mutex_unlock(&m_mtx); }
+
 private:
 	pthread_mutex_t m_mtx;
 };
 
 
 
-class CEvent  
+class CEvent
 {
 // Constructor
 public:
@@ -188,7 +188,7 @@ public:
  	}
 
 	~CEvent()
-	{ 
+	{
 		pthread_mutex_destroy(&m_mtx);
 		pthread_cond_destroy(&m_cnd);
 	}
@@ -196,27 +196,27 @@ public:
 // Operations
 public:
 	BOOL Set()
-	{   
+	{
 		pthread_mutex_lock(&m_mtx);
-        if(!m_bSet)  
+        if(!m_bSet)
         {
 			m_bSet = TRUE;
 			pthread_cond_signal(&m_cnd);
         }
         pthread_mutex_unlock(&m_mtx);
 		return TRUE;
-	} 
+	}
 
 	BOOL Wait()
-	{ 
+	{
 		pthread_mutex_lock( &m_mtx );
 
-        while(!m_bSet) 
+        while(!m_bSet)
         {
             pthread_cond_wait( &m_cnd, &m_mtx );
         }
 
-        if ( !m_bManual ) m_bSet = FALSE; 
+        if ( !m_bManual ) m_bSet = FALSE;
         pthread_mutex_unlock( &m_mtx );
 		return TRUE;
 	}
@@ -228,7 +228,7 @@ public:
 	BOOL Reset()
 	{
 		pthread_mutex_lock( &m_mtx );
-		m_bSet = FALSE; 
+		m_bSet = FALSE;
         pthread_mutex_unlock( &m_mtx );
 		return TRUE;
 	}
@@ -253,5 +253,3 @@ public:
 };
 
 #endif //__THREAD_H__BY_SGCHOI
-
-


### PR DESCRIPTION
This closes several memory leaks, mainly by implementing destructors for the OTExt subclasses.
Some of the  cleanup code could be done in the base class (OTExt) instead of the subclasses (OTExtSnd, OTExtRec), but that would need an additional attribute. I think that makes it basically a design choice, I'd be happy with either solution. See also the [comment in the OTExtRec destructor](https://github.com/schoppmp/OTExtension/blob/3dc5611176bfe4fbf2edd4984e1cb61c9af5b8b4/ot/ot-ext-rec.h#L20).