### PR TITLE
Apply debug flags during compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ ${OBJECTS_CRYPTO}: ${SOURCES_CRYPTO}
 	@cd ENCRYPTO_utils/crypto; ${CC} -c ${INCLUDE} ${CFLAGS} ${BATCH} ${COMPILER_OPTIONS} ${DEBUG_OPTIONS} *.cpp
 
 %.o:%.cpp %.h
-	${CC} $< ${COMPILER_OPTIONS} -c ${INCLUDE} ${CFLAGS} ${BATCH} -o $@
+	${CC} $< ${COMPILER_OPTIONS} ${DEBUG_OPTIONS} -c ${INCLUDE} ${CFLAGS} ${BATCH} -o $@
 
 %.o:%.cpp
-	${CC} $< ${COMPILER_OPTIONS} -c ${INCLUDE} ${CFLAGS} ${BATCH} -o $@
+	${CC} $< ${COMPILER_OPTIONS} ${DEBUG_OPTIONS} -c ${INCLUDE} ${CFLAGS} ${BATCH} -o $@
 
 clean:
 	rm -rf ot.exe test.exe ${OBJECTS_UTIL} ${OBJECTS_OTMAIN} ${OBJECTS_OT} ${OBJECTS_CRYPTO} ${OBJECTS_TEST}


### PR DESCRIPTION
When I was looking into some data races I noticed some incomplete stack traces. This should fix that issue.