### PR TITLE
Fix some memoryleaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SOURCES_CRYPTO=ENCRYPTO_utils/crypto/*.cpp
 OBJECTS_CRYPTO=ENCRYPTO_utils/crypto/*.o
 SOURCES_OT=ot/*.cpp
 OBJECTS_OT=ot/*.o
-COMPILER_OPTIONS=-O2# -mavx -maes  -mpclmul -DRDTSC -DTEST=AES128
+COMPILER_OPTIONS=-std=c++14 -O2# -mavx -maes  -mpclmul -DRDTSC -DTEST=AES128
 DEBUG_OPTIONS=#-g3 -ggdb
 BATCH=
 INCLUDE=-I..

--- a/mains/test.cpp
+++ b/mains/test.cpp
@@ -324,6 +324,7 @@ int main(int argc, char** argv)
 
 	Cleanup();
 	delete crypt;
+	delete glock;
 
 	return 1;
 }

--- a/ot/ot-ext-snd.cpp
+++ b/ot/ot-ext-snd.cpp
@@ -5,6 +5,7 @@
  *      Author: mzohner
  */
 
+#include <memory>
 #include "ot-ext-snd.h"
 
 BOOL OTExtSnd::send(uint64_t numOTs, uint64_t bitlength, uint64_t nsndvals, CBitVector** X, snd_ot_flavor stype,
@@ -289,7 +290,7 @@ BOOL OTExtSnd::verifyOT(uint64_t NumOTs) {
 	uint64_t nSnd;
 	uint8_t* resp;
 
-	channel* chan = new channel(OT_ADMIN_CHANNEL, m_cRcvThread, m_cSndThread);
+	std::unique_ptr<channel> chan = std::make_unique<channel>(OT_ADMIN_CHANNEL, m_cRcvThread, m_cSndThread);
 
 	for (uint64_t i = 0; i < NumOTs; i += OTsPerIteration) {
 		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(NumOTs - i, AES_BITS));
@@ -313,8 +314,6 @@ BOOL OTExtSnd::verifyOT(uint64_t NumOTs) {
 
 	cout << "OT Verification successful" << flush << endl;
 	chan->synchronize_end();
-
-	delete chan;
 
 	return true;
 }


### PR DESCRIPTION
Hello,
I have fixed some memory leaks:

The `CLock *glock` from [line 282 of mains/test.cpp](https://github.com/encryptogroup/OTExtension/blob/6e170e5f261de9b80fda314e06365804d1cce2d3/mains/test.cpp#L282) was not freed at the end of the function.

    
Some allocations in the `verifyOT` methods ([here](https://github.com/encryptogroup/OTExtension/blob/6e170e5f261de9b80fda314e06365804d1cce2d3/ot/ot-ext-rec.cpp#L350) and [here](https://github.com/encryptogroup/OTExtension/blob/6e170e5f261de9b80fda314e06365804d1cce2d3/ot/ot-ext-snd.cpp#L285)) were not freed in case of an verification error.  The manually allocated buffers were replaced with `std::vectors`, the channel object via `std::make_unique`. Since the latter requires C++14, the compiler flag -std=c++14 was added to the Makefile. If desired, I could change that to C++11 and create the `std::unique_ptr` directly.