### PR TITLE
Specify options at runtime

### DIFF
--- a/ot/OTconstants.h
+++ b/ot/OTconstants.h
@@ -26,8 +26,6 @@
 //#define USE_PIPELINED_AES_NI
 //#define SIMPLE_TRANSPOSE //activate the simple transpose, only required for benchmarking, not recommended
 
-#define NUMOTBLOCKS 4096
-#define BUFFER_OT_KEYS NUMOTBLOCKS
 #endif
 
 #define OT_ADMIN_CHANNEL MAX_NUM_COMM_CHANNELS-2

--- a/ot/OTconstants.h
+++ b/ot/OTconstants.h
@@ -24,7 +24,6 @@
 #ifndef ABY_OT
 #define BATCH
 #define VERIFY_OT
-//#define FIXED_KEY_AES_HASHING
 //#define USE_PIPELINED_AES_NI
 //#define SIMPLE_TRANSPOSE //activate the simple transpose, only required for benchmarking, not recommended
 

--- a/ot/OTconstants.h
+++ b/ot/OTconstants.h
@@ -23,7 +23,6 @@
 
 #ifndef ABY_OT
 #define BATCH
-#define VERIFY_OT
 //#define USE_PIPELINED_AES_NI
 //#define SIMPLE_TRANSPOSE //activate the simple transpose, only required for benchmarking, not recommended
 

--- a/ot/alsz-ot-ext-rec.cpp
+++ b/ot/alsz-ot-ext-rec.cpp
@@ -16,9 +16,9 @@ BOOL ALSZOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t internal_numOTs = min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
 	uint64_t lim = myStartPos + internal_numOTs;
 
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(internal_numOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(internal_numOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
-	uint64_t OTwindow = NUMOTBLOCKS * wd_size_bits;
+	uint64_t OTwindow = num_ot_blocks * wd_size_bits;
 	uint64_t** rndmat;
 	bool use_mat_chan = (m_eSndOTFlav == Snd_GC_OT || m_bUseMinEntCorRob);
 	uint32_t nchans = 2;
@@ -73,7 +73,7 @@ BOOL ALSZOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 
 	while (otid < lim) {
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		//nSize = bits_in_bytes(m_nBaseOTs * OTsPerIteration);
 
@@ -447,7 +447,7 @@ void ALSZOTExtRec::ComputeBaseOTs(field_type ftype) {
 		m_tBaseOTQ.push_back(tmp);*/
 	} else {
 		ALSZOTExtSnd* snd = new ALSZOTExtSnd(m_cCrypt, m_cRcvThread, m_cSndThread, m_nBaseOTs, m_nChecks);
-		uint32_t numots = BUFFER_OT_KEYS * m_nBaseOTs;
+		uint32_t numots = buffer_ot_keys * m_nBaseOTs;
 		XORMasking* m_fMaskFct = new XORMasking(m_cCrypt->get_seclvl().symbits);
 		CBitVector** X = (CBitVector**) malloc(sizeof(CBitVector*) * nsndvals);//new CBitVector[nsndvals];
 		uint32_t secparambytes = bits_in_bytes(m_cCrypt->get_seclvl().symbits);
@@ -468,7 +468,7 @@ void ALSZOTExtRec::ComputeBaseOTs(field_type ftype) {
 		buf = (uint8_t*) malloc(secparambytes * nsndvals * m_nBaseOTs);
 
 		OT_AES_KEY_CTX* tmp_keys;
-		for(uint32_t i = 0; i < BUFFER_OT_KEYS; i++) {
+		for(uint32_t i = 0; i < buffer_ot_keys; i++) {
 			//base_ots_snd_t* tmp = (base_ots_snd_t*) malloc(sizeof(base_ots_snd_t));
 			tmp_keys = (OT_AES_KEY_CTX*) malloc(sizeof(OT_AES_KEY_CTX) * m_nBaseOTs * nsndvals);
 			/*for(uint32_t j = 0; j < m_nBaseOTs; j++) {

--- a/ot/alsz-ot-ext-rec.h
+++ b/ot/alsz-ot-ext-rec.h
@@ -27,7 +27,8 @@ class ALSZOTExtRec : public OTExtRec {
 
 public:
 	ALSZOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread,
-			uint32_t nbaseots, uint32_t nchecks) {
+			uint32_t nbaseots, uint32_t nchecks, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs=false;

--- a/ot/alsz-ot-ext-rec.h
+++ b/ot/alsz-ot-ext-rec.h
@@ -27,8 +27,8 @@ class ALSZOTExtRec : public OTExtRec {
 
 public:
 	ALSZOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread,
-			uint32_t nbaseots, uint32_t nchecks, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
+			uint32_t nbaseots, uint32_t nchecks, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs=false;

--- a/ot/alsz-ot-ext-rec.h
+++ b/ot/alsz-ot-ext-rec.h
@@ -27,8 +27,8 @@ class ALSZOTExtRec : public OTExtRec {
 
 public:
 	ALSZOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread,
-			uint32_t nbaseots, uint32_t nchecks, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(use_fixed_key_aes_hashing) {
+			uint32_t nbaseots, uint32_t nchecks, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs=false;

--- a/ot/alsz-ot-ext-snd.cpp
+++ b/ot/alsz-ot-ext-snd.cpp
@@ -11,7 +11,7 @@
 BOOL ALSZOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t myStartPos = id * myNumOTs;
 	uint64_t wd_size_bits = m_nBlockSizeBits;
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
 	uint64_t tmpctr, tmpotlen;
 	uint32_t nchans = 2;
@@ -83,7 +83,7 @@ BOOL ALSZOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 
 	while (OT_ptr < lim) //do while there are still transfers missing
 	{
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - OT_ptr, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - OT_ptr, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 
 #ifdef ZDEBUG
@@ -369,7 +369,7 @@ BOOL ALSZOTExtSnd::CheckConsistency(queue<alsz_snd_check_t>* check_buf_q, channe
 	assert(check_buf.otid == tmpid);
 	assert(check_buf.numblocks == tmpnblocks);
 
-	uint32_t blockoffset = ceil_divide(check_buf.otid, NUMOTBLOCKS * m_nBlockSizeBytes);
+	uint32_t blockoffset = ceil_divide(check_buf.otid, num_ot_blocks * m_nBlockSizeBytes);
 	uint32_t offset = 0 ;//m_nBaseOTs * blockoffset;//TODO, put offset in again when 3-stop ot is implemented
 
 	rcvhashbufptr = rcvhashbuf;
@@ -463,7 +463,7 @@ void ALSZOTExtSnd::ComputeBaseOTs(field_type ftype) {
 		m_tBaseOTQ.push_back(tmp);*/
 	} else {
 		ALSZOTExtRec* rec = new ALSZOTExtRec(m_cCrypt, m_cRcvThread, m_cSndThread, m_nBaseOTs, m_nChecks);
-		uint32_t numots = BUFFER_OT_KEYS * m_nBaseOTs;
+		uint32_t numots = buffer_ot_keys * m_nBaseOTs;
 		XORMasking* m_fMaskFct = new XORMasking(m_cCrypt->get_seclvl().symbits);
 		CBitVector U, resp;
 		uint32_t secparambytes = bits_in_bytes(m_cCrypt->get_seclvl().symbits);
@@ -480,7 +480,7 @@ void ALSZOTExtSnd::ComputeBaseOTs(field_type ftype) {
 		CBitVector* tmp_choices;
 		OT_AES_KEY_CTX* tmp_keys;
 		//assign keys to base OT queue
-		for(uint32_t i = 0; i < BUFFER_OT_KEYS; i++) {
+		for(uint32_t i = 0; i < buffer_ot_keys; i++) {
 			tmp_choices = new CBitVector();
 			tmp_choices->Create(m_nBaseOTs);
 			for (uint32_t j = 0; j < m_nBaseOTs; j++)
@@ -511,7 +511,7 @@ void ALSZOTExtSnd::ComputeBaseOTs(field_type ftype) {
 	//}
 
 	//Extend OTs further and pack into m_tBaseOTQ
-	uint32_t numkeys = BUFFER_OT_KEYS;
+	uint32_t numkeys = buffer_ot_keys;
 	base_ots_t** extended_keys;// = (base_ots_t**) malloc(sizeof(base_ots_t*) * numkeys);
 	for(uint32_t i = 0; i < numkeys; i++) {
 		keys[i] = m_tBaseOTQ.front();
@@ -530,8 +530,8 @@ void ALSZOTExtSnd::ComputeBaseOTs(field_type ftype) {
 /*uint32_t ALSZOTExtSnd::ExtendBaseKeys(uint32_t id, uint64_t nbasekeys, base_ots_t*** out_keys) {
 	assert(m_tBaseOTQ.size() > 0);
 	//+1 to have some offset for future OTs
-	uint32_t req_key_sets = ceil_divide(nbasekeys, NUMOTBLOCKS) + BUFFER_OT_KEYS;
-	if(req_key_sets > m_tBaseOTQ.size()*NUMOTBLOCKS) {
+	uint32_t req_key_sets = ceil_divide(nbasekeys, num_ot_blocks) + buffer_ot_keys;
+	if(req_key_sets > m_tBaseOTQ.size()*num_ot_blocks) {
 		uint32_t numkeys = req_key_sets - m_tBaseOTQ.size();
 		base_ots_t** keys = (base_ots_t**) malloc(sizeof(base_ots_t*) * numkeys);
 		for(uint32_t i = 0; i < numkeys; i++) {

--- a/ot/alsz-ot-ext-snd.h
+++ b/ot/alsz-ot-ext-snd.h
@@ -30,8 +30,8 @@ class ALSZOTExtSnd : public OTExtSnd {
 
 public:
 	ALSZOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint32_t nbaseots,
-			uint32_t nchecks, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(use_fixed_key_aes_hashing) {
+			uint32_t nchecks, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs = false;

--- a/ot/alsz-ot-ext-snd.h
+++ b/ot/alsz-ot-ext-snd.h
@@ -30,8 +30,8 @@ class ALSZOTExtSnd : public OTExtSnd {
 
 public:
 	ALSZOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint32_t nbaseots,
-			uint32_t nchecks, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
+			uint32_t nchecks, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs = false;

--- a/ot/alsz-ot-ext-snd.h
+++ b/ot/alsz-ot-ext-snd.h
@@ -30,7 +30,8 @@ class ALSZOTExtSnd : public OTExtSnd {
 
 public:
 	ALSZOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint32_t nbaseots,
-			uint32_t nchecks) {
+			uint32_t nchecks, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nchecks;
 		m_bDoBaseOTs = false;

--- a/ot/iknp-ot-ext-rec.cpp
+++ b/ot/iknp-ot-ext-rec.cpp
@@ -15,9 +15,9 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	myNumOTs = min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
 	uint64_t lim = myStartPos + myNumOTs;
 
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
-	uint64_t OTwindow = NUMOTBLOCKS * wd_size_bits;
+	uint64_t OTwindow = num_ot_blocks * wd_size_bits;
 	uint64_t** rndmat;
 	channel* chan = new channel(OT_BASE_CHANNEL+id, m_cRcvThread, m_cSndThread);
 
@@ -58,7 +58,7 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 
 	while (otid < lim) {
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		//nSize = bits_in_bytes(m_nBaseOTs * OTsPerIteration);
 

--- a/ot/iknp-ot-ext-rec.h
+++ b/ot/iknp-ot-ext-rec.h
@@ -22,8 +22,8 @@
 class IKNPOTExtRec : public OTExtRec {
 
 public:
-	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
+	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/iknp-ot-ext-rec.h
+++ b/ot/iknp-ot-ext-rec.h
@@ -22,8 +22,8 @@
 class IKNPOTExtRec : public OTExtRec {
 
 public:
-	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(use_fixed_key_aes_hashing) {
+	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/iknp-ot-ext-rec.h
+++ b/ot/iknp-ot-ext-rec.h
@@ -22,7 +22,8 @@
 class IKNPOTExtRec : public OTExtRec {
 
 public:
-	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread) {
+	IKNPOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(use_fixed_key_aes_hashing) {
 		InitRec(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/iknp-ot-ext-snd.cpp
+++ b/ot/iknp-ot-ext-snd.cpp
@@ -11,7 +11,7 @@
 BOOL IKNPOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t myStartPos = id * myNumOTs;
 	uint64_t wd_size_bits = m_nBlockSizeBits;
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
 	channel* chan = new channel(OT_BASE_CHANNEL+id, m_cRcvThread, m_cSndThread);
 	uint64_t tmpctr, tmpotlen;
@@ -65,7 +65,7 @@ BOOL IKNPOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 
 	while (otid < lim) //do while there are still transfers missing
 	{
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 
 #ifdef ZDEBUG

--- a/ot/iknp-ot-ext-snd.h
+++ b/ot/iknp-ot-ext-snd.h
@@ -13,7 +13,8 @@
 class IKNPOTExtSnd : public OTExtSnd {
 
 public:
-	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread) {
+	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/iknp-ot-ext-snd.h
+++ b/ot/iknp-ot-ext-snd.h
@@ -13,8 +13,8 @@
 class IKNPOTExtSnd : public OTExtSnd {
 
 public:
-	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(use_fixed_key_aes_hashing) {
+	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/iknp-ot-ext-snd.h
+++ b/ot/iknp-ot-ext-snd.h
@@ -13,8 +13,8 @@
 class IKNPOTExtSnd : public OTExtSnd {
 
 public:
-	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
+	IKNPOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		InitSnd(crypt, rcvthread, sndthread, crypt->get_seclvl().symbits);
 	}
 	;

--- a/ot/kk-ot-ext-rec.cpp
+++ b/ot/kk-ot-ext-rec.cpp
@@ -33,9 +33,9 @@ BOOL KKOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	}
 
 
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
-	uint64_t OTwindow = NUMOTBLOCKS * wd_size_bits;
+	uint64_t OTwindow = num_ot_blocks * wd_size_bits;
 	uint64_t** rndmat;
 	uint64_t processedOTs;
 	channel* chan = new channel(OT_BASE_CHANNEL+id, m_cRcvThread, m_cSndThread);
@@ -82,7 +82,7 @@ BOOL KKOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 
 	while (otid < lim) {
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		processedOTs = min(lim - otid, OTsPerIteration);
 		//nSize = bits_in_bytes(m_nBaseOTs * OTsPerIteration);

--- a/ot/kk-ot-ext-rec.h
+++ b/ot/kk-ot-ext-rec.h
@@ -15,8 +15,8 @@
 class KKOTExtRec : public OTExtRec, public KKOTExt {
 
 public:
-	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(use_fixed_key_aes_hashing) {
+	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;//, pad_to_power_of_two(nSndVals));
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/kk-ot-ext-rec.h
+++ b/ot/kk-ot-ext-rec.h
@@ -15,8 +15,8 @@
 class KKOTExtRec : public OTExtRec, public KKOTExt {
 
 public:
-	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
+	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;//, pad_to_power_of_two(nSndVals));
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/kk-ot-ext-rec.h
+++ b/ot/kk-ot-ext-rec.h
@@ -15,7 +15,8 @@
 class KKOTExtRec : public OTExtRec, public KKOTExt {
 
 public:
-	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread) {
+	KKOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;//, pad_to_power_of_two(nSndVals));
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/kk-ot-ext-snd.cpp
+++ b/ot/kk-ot-ext-snd.cpp
@@ -20,7 +20,7 @@ BOOL KKOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t myStartPos1ooN = ceil_divide(myStartPos, diff_choicecodes);
 
 	uint64_t wd_size_bits = m_nBlockSizeBits;
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
 	channel* chan = new channel(OT_BASE_CHANNEL+id, m_cRcvThread, m_cSndThread);
 	uint64_t tmpctr, tmpotlen;
@@ -80,7 +80,7 @@ BOOL KKOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 
 	while (otid < lim) //do while there are still transfers missing
 	{
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		processedOTs = min(lim - otid, OTsPerIteration);
 

--- a/ot/kk-ot-ext-snd.h
+++ b/ot/kk-ot-ext-snd.h
@@ -14,7 +14,8 @@
 class KKOTExtSnd : public OTExtSnd, public KKOTExt {
 
 public:
-	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread) {
+	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/kk-ot-ext-snd.h
+++ b/ot/kk-ot-ext-snd.h
@@ -14,8 +14,8 @@
 class KKOTExtSnd : public OTExtSnd, public KKOTExt {
 
 public:
-	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(use_fixed_key_aes_hashing) {
+	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/kk-ot-ext-snd.h
+++ b/ot/kk-ot-ext-snd.h
@@ -14,8 +14,8 @@
 class KKOTExtSnd : public OTExtSnd, public KKOTExt {
 
 public:
-	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
+	KKOTExtSnd(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t numbaseots = 2*crypt->get_seclvl().symbits;
 
 		//assert(pad_to_power_of_two(nSndVals) == nSndVals); //TODO right now only supports power of two nSndVals

--- a/ot/nnob-ot-ext-rec.cpp
+++ b/ot/nnob-ot-ext-rec.cpp
@@ -16,9 +16,9 @@ BOOL NNOBOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	myNumOTs = min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
 	uint64_t lim = myStartPos + myNumOTs;
 
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
-	uint64_t OTwindow = NUMOTBLOCKS * wd_size_bits;
+	uint64_t OTwindow = num_ot_blocks * wd_size_bits;
 	uint64_t** rndmat;
 	bool use_mat_chan = (m_eSndOTFlav == Snd_GC_OT || m_bUseMinEntCorRob);
 	uint32_t nchans = 2;
@@ -65,7 +65,7 @@ BOOL NNOBOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 
 	while (otid < lim) {
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		//nSize = bits_in_bytes(m_nBaseOTs * OTsPerIteration);
 

--- a/ot/nnob-ot-ext-rec.h
+++ b/ot/nnob-ot-ext-rec.h
@@ -24,8 +24,8 @@ typedef struct nnob_rcv_check_ctx {
 class NNOBOTExtRec : public OTExtRec {
 
 public:
-	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
+	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots/2;

--- a/ot/nnob-ot-ext-rec.h
+++ b/ot/nnob-ot-ext-rec.h
@@ -24,8 +24,8 @@ typedef struct nnob_rcv_check_ctx {
 class NNOBOTExtRec : public OTExtRec {
 
 public:
-	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtRec(use_fixed_key_aes_hashing) {
+	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots/2;

--- a/ot/nnob-ot-ext-rec.h
+++ b/ot/nnob-ot-ext-rec.h
@@ -24,7 +24,8 @@ typedef struct nnob_rcv_check_ctx {
 class NNOBOTExtRec : public OTExtRec {
 
 public:
-	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true) {
+	NNOBOTExtRec(crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtRec(use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitRec(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots/2;

--- a/ot/nnob-ot-ext-snd.cpp
+++ b/ot/nnob-ot-ext-snd.cpp
@@ -11,7 +11,7 @@
 BOOL NNOBOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t myStartPos = id * myNumOTs;
 	uint64_t wd_size_bits = m_nBlockSizeBits;
-	uint64_t processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
 	uint64_t tmpctr, tmpotlen;
 	uint32_t nchans = 2;
@@ -78,7 +78,7 @@ BOOL NNOBOTExtSnd::sender_routine(uint32_t id, uint64_t myNumOTs) {
 
 	while (OT_ptr < lim) //do while there are still transfers missing
 	{
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(lim - OT_ptr, wd_size_bits));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - OT_ptr, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 
 #ifdef ZDEBUG
@@ -244,7 +244,7 @@ nnob_snd_check_t* NNOBOTExtSnd::UpdateCheckBuf(uint8_t* tocheckseed, uint8_t* to
 	uint8_t *idbtmpbuf = (BYTE*) malloc(sizeof(BYTE) * rowbytelen);
 	uint8_t *seedptr, *rcvptr;
 
-	//uint32_t blockoffset = ceil_divide(otid, NUMOTBLOCKS * m_nBlockSizeBits);
+	//uint32_t blockoffset = ceil_divide(otid, num_ot_blocks * m_nBlockSizeBits);
 	uint32_t blockid = 0; //TODO bring in as soon as 3-step OT is implemented
 
 	check_buf->otid = otid;

--- a/ot/nnob-ot-ext-snd.h
+++ b/ot/nnob-ot-ext-snd.h
@@ -24,7 +24,8 @@ typedef struct nnob_snd_check_ctx {
 class NNOBOTExtSnd : public OTExtSnd {
 
 public:
-	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true) {
+	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots / 2;

--- a/ot/nnob-ot-ext-snd.h
+++ b/ot/nnob-ot-ext-snd.h
@@ -24,8 +24,8 @@ typedef struct nnob_snd_check_ctx {
 class NNOBOTExtSnd : public OTExtSnd {
 
 public:
-	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
+	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, uint64_t num_ot_blocks=4096, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots / 2;

--- a/ot/nnob-ot-ext-snd.h
+++ b/ot/nnob-ot-ext-snd.h
@@ -24,8 +24,8 @@ typedef struct nnob_snd_check_ctx {
 class NNOBOTExtSnd : public OTExtSnd {
 
 public:
-	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool use_fixed_key_aes_hashing=false)
-		: OTExtSnd(use_fixed_key_aes_hashing) {
+	NNOBOTExtSnd( crypto* crypt, RcvThread* rcvthread, SndThread* sndthread, bool dobaseots=true, bool verify_ot=true, bool use_fixed_key_aes_hashing=false)
+		: OTExtSnd(verify_ot, use_fixed_key_aes_hashing) {
 		uint32_t nbaseots = ceil_divide(crypt->get_seclvl().symbits * 8, 3);
 		InitSnd(crypt, rcvthread, sndthread, nbaseots);
 		m_nChecks = nbaseots / 2;

--- a/ot/ot-ext-rec.cpp
+++ b/ot/ot-ext-rec.cpp
@@ -67,10 +67,10 @@ BOOL OTExtRec::start_receive(uint32_t numThreads) {
 	//	m_nRet.Copy(m_vTempOTMasks.GetArr(), 0, ceil_divide(m_nOTs * m_nBitLength, 8));
 	//}
 	//m_vTempOTMasks.delCBitVector();
-#ifdef VERIFY_OT
+	if (verify_ot) {
 	//Wait for the signal of the corresponding sender thread
-	verifyOT(m_nOTs);
-#endif
+		verifyOT(m_nOTs);
+	}
 
 	return true;
 }

--- a/ot/ot-ext-rec.cpp
+++ b/ot/ot-ext-rec.cpp
@@ -238,14 +238,15 @@ void OTExtRec::HashValues(CBitVector* T, CBitVector* seedbuf, CBitVector* maskbu
 
 #endif
 
-#ifdef FIXED_KEY_AES_HASHING
-			FixedKeyHashing(m_kCRFKey, bufptr, Tptr, hash_buf, i, ceil_divide(m_nSymSecParam, 8), m_cCrypt);
-#else
-			memcpy(inbuf, &global_OT_ptr, sizeof(uint64_t));
-			memcpy(inbuf+sizeof(uint64_t), Tptr, rowbytelen);
-			m_cCrypt->hash_buf(resbuf, aes_key_bytes, inbuf, hashinbytelen, hash_buf);
-			memcpy(bufptr, resbuf, aes_key_bytes);
-#endif
+			if (use_fixed_key_aes_hashing)
+			{
+				FixedKeyHashing(m_kCRFKey, bufptr, Tptr, hash_buf, i, ceil_divide(m_nSymSecParam, 8), m_cCrypt);
+			} else {
+				memcpy(inbuf, &global_OT_ptr, sizeof(uint64_t));
+				memcpy(inbuf+sizeof(uint64_t), Tptr, rowbytelen);
+				m_cCrypt->hash_buf(resbuf, aes_key_bytes, inbuf, hashinbytelen, hash_buf);
+				memcpy(bufptr, resbuf, aes_key_bytes);
+			}
 
 
 #ifdef DEBUG_OT_HASH_OUT

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -15,8 +15,8 @@ class OTExtRec : public OTExt {
 
 public:
 
-	OTExtRec(bool verify_ot, bool use_fixed_key_aes_hashing)
-		: OTExt(verify_ot, use_fixed_key_aes_hashing) {};
+	OTExtRec(uint64_t num_ot_blocks, bool verify_ot, bool use_fixed_key_aes_hashing)
+		: OTExt(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {};
 	virtual ~OTExtRec(){
 		// TODO: nsndvals is currently hardcoeded in OTExtRec::ComputePKBaseOTs()
 		// maybe add it as a private attribute to class OTExt and move the

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -15,7 +15,8 @@ class OTExtRec : public OTExt {
 
 public:
 
-	OTExtRec(){};
+	OTExtRec(bool use_fixed_key_aes_hashing)
+		: OTExt(use_fixed_key_aes_hashing) {};
 	virtual ~OTExtRec(){
 		// TODO: nsndvals is currently hardcoeded in OTExtRec::ComputePKBaseOTs()
 		// maybe add it as a private attribute to class OTExt and move the

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -15,8 +15,8 @@ class OTExtRec : public OTExt {
 
 public:
 
-	OTExtRec(bool use_fixed_key_aes_hashing)
-		: OTExt(use_fixed_key_aes_hashing) {};
+	OTExtRec(bool verify_ot, bool use_fixed_key_aes_hashing)
+		: OTExt(verify_ot, use_fixed_key_aes_hashing) {};
 	virtual ~OTExtRec(){
 		// TODO: nsndvals is currently hardcoeded in OTExtRec::ComputePKBaseOTs()
 		// maybe add it as a private attribute to class OTExt and move the

--- a/ot/ot-ext-snd.cpp
+++ b/ot/ot-ext-snd.cpp
@@ -56,9 +56,10 @@ BOOL OTExtSnd::start_send(uint32_t numThreads) {
 		delete sThreads[i];
 	}
 
-#ifdef VERIFY_OT
-	verifyOT(m_nOTs);
-#endif
+	if (verify_ot) {
+		verifyOT(m_nOTs);
+	}
+
 	return true;
 }
 

--- a/ot/ot-ext-snd.cpp
+++ b/ot/ot-ext-snd.cpp
@@ -213,14 +213,14 @@ void OTExtSnd::HashValues(CBitVector* Q, CBitVector* seedbuf, CBitVector* snd_bu
 #endif
 
 			if(m_eSndOTFlav != Snd_GC_OT) {
-#ifdef FIXED_KEY_AES_HASHING
-				FixedKeyHashing(m_kCRFKey, sbp[u], (BYTE*) Qptr, hash_buf, i, ceil_divide(m_nSymSecParam, 8), m_cCrypt);
-#else
-				memcpy(inbuf, &global_OT_ptr, sizeof(uint64_t));
-				memcpy(inbuf+sizeof(uint64_t), Q->GetArr() + i * wd_size_bytes, rowbytelen);
-				m_cCrypt->hash_buf(resbuf, aes_key_bytes, inbuf, hashinbytelen, hash_buf);
-				memcpy(sbp[u], resbuf, aes_key_bytes);
-#endif
+				if (use_fixed_key_aes_hashing) {
+					FixedKeyHashing(m_kCRFKey, sbp[u], (BYTE*) Qptr, hash_buf, i, ceil_divide(m_nSymSecParam, 8), m_cCrypt);
+				} else {
+					memcpy(inbuf, &global_OT_ptr, sizeof(uint64_t));
+					memcpy(inbuf+sizeof(uint64_t), Q->GetArr() + i * wd_size_bytes, rowbytelen);
+					m_cCrypt->hash_buf(resbuf, aes_key_bytes, inbuf, hashinbytelen, hash_buf);
+					memcpy(sbp[u], resbuf, aes_key_bytes);
+				}
 			} else {
 
 				BitMatrixMultiplication(tmpbufb, bits_in_bytes(m_nBitLength), Q->GetArr() + i * wd_size_bytes, m_nBaseOTs, mat_mul, tmpbuf);

--- a/ot/ot-ext-snd.cpp
+++ b/ot/ot-ext-snd.cpp
@@ -294,7 +294,7 @@ BOOL OTExtSnd::verifyOT(uint64_t NumOTs) {
 	std::unique_ptr<channel> chan = std::make_unique<channel>(OT_ADMIN_CHANNEL, m_cRcvThread, m_cSndThread);
 
 	for (uint64_t i = 0; i < NumOTs; i += OTsPerIteration) {
-		processedOTBlocks = min((uint64_t) NUMOTBLOCKS, ceil_divide(NumOTs - i, AES_BITS));
+		processedOTBlocks = min(num_ot_blocks, ceil_divide(NumOTs - i, AES_BITS));
 		OTsPerIteration = min(processedOTBlocks * AES_BITS, NumOTs - i);
 		nSnd = ceil_divide(OTsPerIteration * m_nBitLength, 8);
 

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -13,8 +13,8 @@
 class OTExtSnd : public OTExt {
 
 public:
-	OTExtSnd(bool verify_ot, bool use_fixed_key_aes_hashing)
-		: OTExt(verify_ot, use_fixed_key_aes_hashing) {};
+	OTExtSnd(uint64_t num_ot_blocks, bool verify_ot, bool use_fixed_key_aes_hashing)
+		: OTExt(num_ot_blocks, verify_ot, use_fixed_key_aes_hashing) {};
 
 	virtual ~OTExtSnd() {
 		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -13,7 +13,8 @@
 class OTExtSnd : public OTExt {
 
 public:
-	OTExtSnd() {};
+	OTExtSnd(bool use_fixed_key_aes_hashing)
+		: OTExt(use_fixed_key_aes_hashing) {};
 
 	virtual ~OTExtSnd() {
 		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -13,8 +13,8 @@
 class OTExtSnd : public OTExt {
 
 public:
-	OTExtSnd(bool use_fixed_key_aes_hashing)
-		: OTExt(use_fixed_key_aes_hashing) {};
+	OTExtSnd(bool verify_ot, bool use_fixed_key_aes_hashing)
+		: OTExt(verify_ot, use_fixed_key_aes_hashing) {};
 
 	virtual ~OTExtSnd() {
 		for(size_t i = 0; i < m_tBaseOTChoices.size(); i++) {

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -97,8 +97,8 @@ typedef struct mask_buf_ctx {
 class OTExt {
 
 public:
-	OTExt(bool use_fixed_key_aes_hashing)
-		: use_fixed_key_aes_hashing(use_fixed_key_aes_hashing) {};
+	OTExt(bool verify_ot, bool use_fixed_key_aes_hashing)
+		: verify_ot(verify_ot), use_fixed_key_aes_hashing(use_fixed_key_aes_hashing) {};
 	virtual ~OTExt() {
 		if (use_fixed_key_aes_hashing) {
 			m_cCrypt->clean_aes_key(m_kCRFKey);
@@ -174,6 +174,7 @@ protected:
 	BaseOT* m_cBaseOT;
 
 	// (previously compile time options)
+	const bool verify_ot;
 	const bool use_fixed_key_aes_hashing;
 
 	AES_KEY_CTX* m_kCRFKey;

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -50,10 +50,8 @@
 #else
 	typedef AES_KEY_CTX OT_AES_KEY_CTX;
 
-#ifdef FIXED_KEY_AES_HASHING
 static const uint8_t fixed_key_aes_seed[32] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
 		0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
-#endif
 
 	static void InitAESKey(OT_AES_KEY_CTX* ctx, uint8_t* keybytes, uint32_t numkeys, crypto* crypt) {
 		BYTE* pBufIdx = keybytes;
@@ -99,12 +97,13 @@ typedef struct mask_buf_ctx {
 class OTExt {
 
 public:
-	OTExt(){};
+	OTExt(bool use_fixed_key_aes_hashing)
+		: use_fixed_key_aes_hashing(use_fixed_key_aes_hashing) {};
 	virtual ~OTExt() {
-#ifdef FIXED_KEY_AES_HASHING
-		m_cCrypt->clean_aes_key(m_kCRFKey);
-		free(m_kCRFKey);
-#endif
+		if (use_fixed_key_aes_hashing) {
+			m_cCrypt->clean_aes_key(m_kCRFKey);
+			free(m_kCRFKey);
+		}
 	};
 
 	virtual void ComputeBaseOTs(field_type ftype) = 0;
@@ -142,10 +141,10 @@ protected:
 	void InitPRFKeys(OT_AES_KEY_CTX* base_ot_keys, uint8_t* keybytes, uint32_t nbasekeys) {
 		InitAESKey(base_ot_keys, keybytes, nbasekeys, m_cCrypt);
 
-#ifdef FIXED_KEY_AES_HASHING
-		m_kCRFKey = (AES_KEY_CTX*) malloc(sizeof(AES_KEY_CTX));
-		m_cCrypt->init_aes_key(m_kCRFKey, (uint8_t*) fixed_key_aes_seed);
-#endif
+		if (use_fixed_key_aes_hashing) {
+			m_kCRFKey = (AES_KEY_CTX*) malloc(sizeof(AES_KEY_CTX));
+			m_cCrypt->init_aes_key(m_kCRFKey, (uint8_t*) fixed_key_aes_seed);
+		}
 	}
 
 	snd_ot_flavor m_eSndOTFlav;
@@ -174,9 +173,10 @@ protected:
 
 	BaseOT* m_cBaseOT;
 
-#ifdef FIXED_KEY_AES_HASHING
+	// (previously compile time options)
+	const bool use_fixed_key_aes_hashing;
+
 	AES_KEY_CTX* m_kCRFKey;
-#endif
 };
 
 static void fillRndMatrix(uint8_t* seed, uint64_t** mat, uint64_t cols, uint64_t rows, crypto* crypt) {
@@ -232,7 +232,6 @@ static void BitMatrixMultiplication(uint8_t* resbuf, uint64_t resbytelen, uint8_
 
 
 
-#ifdef FIXED_KEY_AES_HASHING
 inline void FixedKeyHashing(AES_KEY_CTX* aeskey, BYTE* outbuf, BYTE* inbuf, BYTE* tmpbuf, uint64_t id, uint32_t bytessecparam, crypto* crypt) {
 	assert(bytessecparam <= AES_BYTES);
 #ifdef HIGH_SPEED_ROT_LT
@@ -258,7 +257,6 @@ inline void FixedKeyHashing(AES_KEY_CTX* aeskey, BYTE* outbuf, BYTE* inbuf, BYTE
 	}
 #endif
 }
-#endif
 
 
 

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -97,8 +97,10 @@ typedef struct mask_buf_ctx {
 class OTExt {
 
 public:
-	OTExt(bool verify_ot, bool use_fixed_key_aes_hashing)
-		: verify_ot(verify_ot), use_fixed_key_aes_hashing(use_fixed_key_aes_hashing) {};
+	OTExt(uint64_t num_ot_blocks, bool verify_ot, bool use_fixed_key_aes_hashing)
+		: num_ot_blocks(num_ot_blocks), buffer_ot_keys(num_ot_blocks),
+		  verify_ot(verify_ot),
+		  use_fixed_key_aes_hashing(use_fixed_key_aes_hashing) {};
 	virtual ~OTExt() {
 		if (use_fixed_key_aes_hashing) {
 			m_cCrypt->clean_aes_key(m_kCRFKey);
@@ -174,6 +176,8 @@ protected:
 	BaseOT* m_cBaseOT;
 
 	// (previously compile time options)
+	const uint64_t num_ot_blocks;
+	const uint64_t buffer_ot_keys;
 	const bool verify_ot;
 	const bool use_fixed_key_aes_hashing;
 


### PR DESCRIPTION
Hi,

I replaced some of the `#define`s in `OTconstants.h` and specify these options in the class `OTExt` instead. This allows us to get rid of the extra `OTconstants.h` header for ABY (cf. encryptogroup/ABY#49).