### PR TITLE
Cleanup includes and header files

### DIFF
--- a/ot/alsz-ot-ext-rec.h
+++ b/ot/alsz-ot-ext-rec.h
@@ -11,9 +11,6 @@
 #define ALSZ_OT_EXT_REC_H_
 
 #include "ot-ext-rec.h"
-#include "alsz-ot-ext-snd.h"
-#include "xormasking.h"
-#include "simpleot.h"
 
 
 typedef struct alsz_rcv_check_ctx {
@@ -52,7 +49,7 @@ public:
 
 private:
 	alsz_rcv_check_t EnqueueSeed(uint8_t* T0, uint8_t* T1, uint64_t otid, uint64_t numblocks);
-	void ComputeOWF(queue<alsz_rcv_check_t>* check_buf_q, channel* check_chan);
+	void ComputeOWF(std::queue<alsz_rcv_check_t>* check_buf_q, channel* check_chan);
 	void ReceiveAndFillMatrix(uint64_t** rndmat, channel* mat_chan);
 
 	//vector<base_ots_snd_t*> m_tBaseOTQ;

--- a/ot/alsz-ot-ext-snd.h
+++ b/ot/alsz-ot-ext-snd.h
@@ -11,9 +11,6 @@
 #define ALSZ_OT_EXT_SND_H_
 
 #include "ot-ext-snd.h"
-#include "alsz-ot-ext-rec.h"
-#include "xormasking.h"
-#include "simpleot.h"
 
 
 typedef struct alsz_snd_check_ctx {
@@ -57,7 +54,7 @@ private:
 	alsz_snd_check_t UpdateCheckBuf(uint8_t* tocheckseed, uint8_t* tocheckrcv, uint64_t otid, uint64_t numblocks, CBitVector* choices, channel* check_chan);
 	void XORandOWF(uint8_t* idaptr, uint8_t* idbptr, uint64_t rowbytelen, uint8_t* tmpbuf, uint8_t* resbuf, uint8_t* hash_buf);
 	void genRandomPermutation(linking_t* outperm, uint32_t nids, uint32_t nperms);
-	BOOL CheckConsistency(queue<alsz_snd_check_t>* check_buf_q, channel* check_chan);
+	BOOL CheckConsistency(std::queue<alsz_snd_check_t>* check_buf_q, channel* check_chan);
 	void FillAndSendRandomMatrix(uint64_t **rndmat, channel* chan);
 
 	bool m_bDoBaseOTs;

--- a/ot/baseOT.h
+++ b/ot/baseOT.h
@@ -8,17 +8,17 @@
 #ifndef BASEOT_H_
 #define BASEOT_H_
 
+#include "../ENCRYPTO_utils/constants.h"
 #include "../ENCRYPTO_utils/typedefs.h"
-#include "../ENCRYPTO_utils/cbitvector.h"
-#include "../ENCRYPTO_utils/socket.h"
 #include "../ENCRYPTO_utils/crypto/crypto.h"
-#include "../ENCRYPTO_utils/channel.h"
-#include <ctime>
+#include "../ENCRYPTO_utils/crypto/pk-crypto.h"
 
+#ifdef DEBUG_BASE_OT_HASH_RET
 #include <iostream>
-#include <cstring>
-#include <fstream>
-#include <time.h>
+#endif
+
+class channel;
+class CBitVector;
 
 
 class BaseOT {
@@ -41,19 +41,19 @@ protected:
 
 	void hashReturn(uint8_t* ret, uint32_t ret_len, uint8_t* val, uint32_t val_len, uint64_t ctr) {
 #ifdef DEBUG_BASE_OT_HASH_RET
-		cout << ctr << " input : ";
+		std::cout << ctr << " input : ";
 		for(uint32_t i = 0; i < val_len; i++) {
-			cout << (hex) << (uint32_t) val[i];
+			std::cout << (std::hex) << (uint32_t) val[i];
 		}
-		cout << (dec) << endl;
+		std::cout << (std::dec) << std::endl;
 #endif
 		m_cCrypto->hash_ctr(ret, ret_len, val, val_len, ctr);
 #ifdef DEBUG_BASE_OT_HASH_RET
-		cout << ctr << " output: ";
+		std::cout << ctr << " output: ";
 		for(uint32_t i = 0; i < ret_len; i++) {
-			cout << (hex) << (uint32_t) ret[i];
+			std::cout << (std::hex) << (uint32_t) ret[i];
 		}
-		cout << (dec) << endl;
+		std::cout << (std::dec) << std::endl;
 #endif
 	}
 

--- a/ot/iknp-ot-ext-rec.cpp
+++ b/ot/iknp-ot-ext-rec.cpp
@@ -6,16 +6,19 @@
  */
 
 #include "iknp-ot-ext-rec.h"
+#include "naor-pinkas.h"
+#include "../ENCRYPTO_utils/channel.h"
+#include "../ENCRYPTO_utils/cbitvector.h"
 
 
 BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	uint64_t myStartPos = id * myNumOTs;
 	uint64_t wd_size_bits = m_nBlockSizeBits;
 
-	myNumOTs = min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
+	myNumOTs = std::min(myNumOTs + myStartPos, m_nOTs) - myStartPos;
 	uint64_t lim = myStartPos + myNumOTs;
 
-	uint64_t processedOTBlocks = min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
+	uint64_t processedOTBlocks = std::min(num_ot_blocks, ceil_divide(myNumOTs, wd_size_bits));
 	uint64_t OTsPerIteration = processedOTBlocks * wd_size_bits;
 	uint64_t OTwindow = num_ot_blocks * wd_size_bits;
 	uint64_t** rndmat;
@@ -40,7 +43,7 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 
 	uint64_t otid = myStartPos;
 
-	queue<mask_block*> mask_queue;
+	std::queue<mask_block*> mask_queue;
 
 	CBitVector maskbuf;
 	maskbuf.Create(m_nBitLength * OTwindow);
@@ -58,13 +61,13 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 
 	while (otid < lim) {
-		processedOTBlocks = min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
+		processedOTBlocks = std::min(num_ot_blocks, ceil_divide(lim - otid, wd_size_bits));
 		OTsPerIteration = processedOTBlocks * wd_size_bits;
 		//nSize = bits_in_bytes(m_nBaseOTs * OTsPerIteration);
 
 #ifdef ZDEBUG
-		cout << "Receiver thread " << id << " processing block " << otid <<
-				" with length: " << OTsPerIteration << ", and limit: " << lim << endl;
+		std::cout << "Receiver thread " << id << " processing block " << otid <<
+				" with length: " << OTsPerIteration << ", and limit: " << lim << std::endl;
 #endif
 
 
@@ -89,7 +92,7 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 		totalTnsTime += getMillies(tempStart, tempEnd);
 		gettimeofday(&tempStart, NULL);
 #endif
-		HashValues(&T, &seedbuf, &maskbuf, otid, min(lim - otid, OTsPerIteration), rndmat);
+		HashValues(&T, &seedbuf, &maskbuf, otid, std::min(lim - otid, OTsPerIteration), rndmat);
 #ifdef OTTiming
 		gettimeofday(&tempEnd, NULL);
 		totalHshTime += getMillies(tempStart, tempEnd);
@@ -103,8 +106,8 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 #endif
 		SetOutput(&maskbuf, otid, OTsPerIteration, &mask_queue, chan);//ReceiveAndUnMask(chan);
 
-		//counter += min(lim - OT_ptr, OTsPerIteration);
-		otid += min(lim - otid, OTsPerIteration);
+		//counter += std::min(lim - OT_ptr, OTsPerIteration);
+		otid += std::min(lim - otid, OTsPerIteration);
 #ifdef OTTiming
 		gettimeofday(&tempEnd, NULL);
 		totalRcvTime += getMillies(tempStart, tempEnd);
@@ -127,7 +130,7 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	}
 
 #ifdef ZDEBUG
-	cout << "Receiver thread " << id << " finished " << endl;
+	std::cout << "Receiver thread " << id << " finished " << std::endl;
 #endif
 
 
@@ -136,14 +139,14 @@ BOOL IKNPOTExtRec::receiver_routine(uint32_t id, uint64_t myNumOTs) {
 	if(m_eSndOTFlav==Snd_GC_OT)
 		freeRndMatrix(rndmat, m_nBaseOTs);
 #ifdef OTTiming
-	cout << "Receiver time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << endl;
-	cout << "Time needed for: " << endl;
-	cout << "\t Matrix Generation:\t" << totalMtxTime << " ms" << endl;
-	cout << "\t Base OT Masking:\t" << totalMaskTime << " ms" << endl;
-	cout << "\t Sending Matrix:\t" << totalSndTime << " ms" << endl;
-	cout << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << endl;
-	cout << "\t Hashing Matrix:\t" << totalHshTime << " ms" << endl;
-	cout << "\t Receiving Values:\t" << totalRcvTime << " ms" << endl;
+	std::cout << "Receiver time benchmark for performing " << myNumOTs << " OTs on " << m_nBitLength << " bit strings" << std::endl;
+	std::cout << "Time needed for: " << std::endl;
+	std::cout << "\t Matrix Generation:\t" << totalMtxTime << " ms" << std::endl;
+	std::cout << "\t Base OT Masking:\t" << totalMaskTime << " ms" << std::endl;
+	std::cout << "\t Sending Matrix:\t" << totalSndTime << " ms" << std::endl;
+	std::cout << "\t Transposing Matrix:\t" << totalTnsTime << " ms" << std::endl;
+	std::cout << "\t Hashing Matrix:\t" << totalHshTime << " ms" << std::endl;
+	std::cout << "\t Receiving Values:\t" << totalRcvTime << " ms" << std::endl;
 #endif
 
 	T.delCBitVector();

--- a/ot/kk-ot-ext-rec.h
+++ b/ot/kk-ot-ext-rec.h
@@ -41,10 +41,10 @@ public:
 
 private:
 	void GenerateChoiceCodes(CBitVector* choicecodes, CBitVector* vSnd, CBitVector* T, uint32_t startpos, uint32_t len);
-	void KKSetOutput(CBitVector* maskbuf, uint64_t otid, uint64_t otlen, queue<mask_block*>* mask_queue, channel* chan);
+	void KKSetOutput(CBitVector* maskbuf, uint64_t otid, uint64_t otlen, std::queue<mask_block*>* mask_queue, channel* chan);
 	void KKHashValues(CBitVector* T, CBitVector* seedbuf, CBitVector* maskbuf, uint64_t OT_ptr, uint64_t OT_len, uint64_t** mat_mul);
 	void KKMaskBaseOTs(CBitVector* T, CBitVector* SndBuf, uint64_t numblocks);
-	void KKReceiveAndUnMask(channel* chan, queue<mask_block*>* mask_queue);
+	void KKReceiveAndUnMask(channel* chan, std::queue<mask_block*>* mask_queue);
 	//uint64_t** m_vCodeWords;
 };
 

--- a/ot/naor-pinkas.cpp
+++ b/ot/naor-pinkas.cpp
@@ -6,6 +6,11 @@
  */
 
 #include "naor-pinkas.h"
+#include "../ENCRYPTO_utils/cbitvector.h"
+#include "../ENCRYPTO_utils/channel.h"
+#include "../ENCRYPTO_utils/crypto/ecc-pk-crypto.h"
+#include "../ENCRYPTO_utils/crypto/pk-crypto.h"
+#include <cstdlib>
 
 void NaorPinkas::Receiver(uint32_t nSndVals, uint32_t nOTs, CBitVector* choices, channel* chan, uint8_t* ret) {
 

--- a/ot/nnob-ot-ext-rec.h
+++ b/ot/nnob-ot-ext-rec.h
@@ -11,7 +11,6 @@
 #define NNOB_OT_EXT_REC_H_
 
 #include "ot-ext-rec.h"
-#include "simpleot.h"
 
 
 
@@ -43,7 +42,7 @@ public:
 
 private:
 	nnob_rcv_check_t EnqueueSeed(uint8_t* T0, uint64_t otid, uint64_t numblocks);
-	void ComputeOWF(queue<nnob_rcv_check_t>* check_buf_q, channel* check_chan);
+	void ComputeOWF(std::queue<nnob_rcv_check_t>* check_buf_q, channel* check_chan);
 	void ReceiveAndFillMatrix(uint64_t** rndmat, channel* mat_chan);
 	bool m_bDoBaseOTs;
 };

--- a/ot/nnob-ot-ext-snd.h
+++ b/ot/nnob-ot-ext-snd.h
@@ -11,7 +11,6 @@
 #define NNOB_OT_EXT_SND_H_
 
 #include "ot-ext-snd.h"
-#include "simpleot.h"
 
 typedef struct nnob_snd_check_ctx {
 	uint64_t otid;
@@ -46,7 +45,7 @@ private:
 	nnob_snd_check_t* UpdateCheckBuf(uint8_t* tocheckseed, uint8_t* tocheckrcv, uint64_t otid, uint64_t numblocks, channel* check_chan);
 	void XORandOWF(uint8_t* idaptr, uint8_t* idbptr, uint64_t rowbytelen, uint8_t* tmpbuf, uint8_t* resbuf, uint8_t* hash_buf);
 	void genRandomMapping(linking_t* outperm, uint32_t nids);
-	BOOL CheckConsistency(queue<nnob_snd_check_t*>* check_buf_q, channel* check_chan);
+	BOOL CheckConsistency(std::queue<nnob_snd_check_t*>* check_buf_q, channel* check_chan);
 	void FillAndSendRandomMatrix(uint64_t **rndmat, channel* chan);
 
 	bool m_bDoBaseOTs;

--- a/ot/ot-ext-rec.h
+++ b/ot/ot-ext-rec.h
@@ -10,6 +10,8 @@
 
 #include "ot-ext.h"
 
+class channel;
+class CBitVector;
 
 class OTExtRec : public OTExt {
 
@@ -49,8 +51,8 @@ protected:
 	void MaskBaseOTs(CBitVector* T, CBitVector* SndBuf, uint64_t OTid, uint64_t numblocks);
 	void SendMasks(CBitVector* Sndbuf, channel* chan, uint64_t OTid, uint64_t processedOTs, uint64_t rem_row = 1);
 	void HashValues(CBitVector* T, CBitVector* seedbuf, CBitVector* maskbuf, uint64_t ctr, uint64_t lim, uint64_t** mat);
-	void SetOutput(CBitVector* maskbuf, uint64_t otid, uint64_t otlen, queue<mask_block*>* mask_queue, channel* chan);
-	void ReceiveAndUnMask(channel* chan, queue<mask_block*>* mask_queue);
+	void SetOutput(CBitVector* maskbuf, uint64_t otid, uint64_t otlen, std::queue<mask_block*>* mask_queue, channel* chan);
+	void ReceiveAndUnMask(channel* chan, std::queue<mask_block*>* mask_queue);
 	void ReceiveAndXORCorRobVector(CBitVector* T, uint64_t OT_len, channel* chan);
 	BOOL verifyOT(uint64_t myNumOTs);
 

--- a/ot/ot-ext-snd.h
+++ b/ot/ot-ext-snd.h
@@ -9,6 +9,9 @@
 #define OT_EXTENSION_SENDER_H_
 
 #include "ot-ext.h"
+#include <vector>
+
+class channel;
 
 class OTExtSnd : public OTExt {
 
@@ -64,7 +67,7 @@ protected:
 
 	BYTE* m_vSeed;
 
-	vector<CBitVector*> m_tBaseOTChoices;
+    std::vector<CBitVector*> m_tBaseOTChoices;
 
 
 	class OTSenderThread: public CThread {

--- a/ot/ot-ext.h
+++ b/ot/ot-ext.h
@@ -28,18 +28,15 @@
 //#define DEBUG_KK_OTBREAKDOWN
 
 
-#include "../ENCRYPTO_utils/typedefs.h"
-#include "../ENCRYPTO_utils/socket.h"
-#include "../ENCRYPTO_utils/thread.h"
-#include "../ENCRYPTO_utils/cbitvector.h"
-#include "../ENCRYPTO_utils/crypto/crypto.h"
 #include "maskingfunction.h"
-#include "../ENCRYPTO_utils/constants.h"
-#include "../ENCRYPTO_utils/channel.h"
 #include "../ENCRYPTO_utils/rcvthread.h"
 #include "../ENCRYPTO_utils/sndthread.h"
-#include "naor-pinkas.h"
+#include "../ENCRYPTO_utils/utils.h"
+#include "../ENCRYPTO_utils/crypto/crypto.h"
 #include "OTconstants.h"
+
+class BaseOT;
+class CBitVector;
 
 #ifdef USE_PIPELINED_AES_NI
 	typedef ROUND_KEYS OT_AES_KEY_CTX;
@@ -169,7 +166,7 @@ protected:
 	SndThread* m_cSndThread;
 	RcvThread* m_cRcvThread;
 
-	vector<OT_AES_KEY_CTX*> m_tBaseOTKeys;
+    std::vector<OT_AES_KEY_CTX*> m_tBaseOTKeys;
 
 	MaskingFunction* m_fMaskFct;
 

--- a/ot/pvwddh.cpp
+++ b/ot/pvwddh.cpp
@@ -1,4 +1,6 @@
 #include "pvwddh.h"
+#include "../ENCRYPTO_utils/channel.h"
+#include "../ENCRYPTO_utils/cbitvector.h"
 
 void PVWDDH::Receiver(uint32_t nSndVals, uint32_t nOTs, CBitVector* choices, channel* chan, uint8_t* retbuf) {
 
@@ -256,11 +258,11 @@ void PVWDDH::Sender(uint32_t nSndVals, uint32_t nOTs, channel* chan, uint8_t* re
 
 		//if(gchk != zkchk) {
 		if(!gchk->eq(zkchk)) {
-			cout << "Zero-knowledge proof for base-OTs failed!" << endl;
+			std::cout << "Zero-knowledge proof for base-OTs failed!" << std::endl;
 			gchk->print();
-			cout << ", vs. ";
+			std::cout << ", vs. ";
 			zkchk->print();
-			cout << endl;
+			std::cout << std::endl;
 			exit(0);
 		}
 	}

--- a/ot/simpleot.cpp
+++ b/ot/simpleot.cpp
@@ -1,4 +1,9 @@
 #include "simpleot.h"
+#include "../ENCRYPTO_utils/cbitvector.h"
+#include "../ENCRYPTO_utils/channel.h"
+#include "../ENCRYPTO_utils/crypto/crypto.h"
+#include "../ENCRYPTO_utils/crypto/pk-crypto.h"
+#include <cstdlib>
 
 void SimpleOT::Receiver(uint32_t nSndVals, uint32_t nOTs, CBitVector* choices, channel* chan, uint8_t* retbuf) {
 

--- a/ot/simpleot.h
+++ b/ot/simpleot.h
@@ -7,6 +7,9 @@
 
 #include "baseOT.h"
 
+class channel;
+class CBitVector;
+
 class SimpleOT : public BaseOT
 {
 


### PR DESCRIPTION
This continues the work of encryptogroup/ENCRYPTO_utils#5 
* use std:: namespace explicitly
* use forward declarations
* remove unnecessary includes
* move includes to .cpp files if possible

ABY breaks ~probably~ definitely on this.