### PR TITLE
fix exit status of the executables

### DIFF
--- a/mains/otmain.cpp
+++ b/mains/otmain.cpp
@@ -1,4 +1,5 @@
 #include "otmain.h"
+#include <cstdlib>
 
 //pthread_mutex_t CLock::share_mtx = PTHREAD_MUTEX_INITIALIZER;
 
@@ -370,7 +371,7 @@ int main(int argc, char** argv)
 	delete crypt;
     delete glock;
 
-	return 1;
+	return EXIT_SUCCESS;
 }
 
 
@@ -404,13 +405,13 @@ int32_t read_test_options(int32_t* argcp, char*** argvp, uint32_t* role, uint64_
 	if (!parse_options(argcp, argvp, options, sizeof(options) / sizeof(parsing_ctx))) {
 		print_usage(*argvp[0], options, sizeof(options) / sizeof(parsing_ctx));
 		cout << "Exiting" << endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 
 	if(printhelp) {
 		print_usage(*argvp[0], options, sizeof(options) / sizeof(parsing_ctx));
 		cout << "Exiting" << endl;
-		exit(0);
+		std::exit(EXIT_FAILURE);
 	}
 
 	assert(*role < 2);

--- a/mains/test.cpp
+++ b/mains/test.cpp
@@ -1,4 +1,5 @@
 #include "test.h"
+#include <cstdlib>
 
 //ot_ext_prot test_prots[] = {IKNP, KK, ALSZ, NNOB};
 ot_ext_prot test_prots[] = {IKNP};
@@ -71,7 +72,7 @@ void assign_param(uint32_t ctr, uint32_t depth, test_options* tops) {
 	case 6: tops->usemecr = test_usemecr[ctr]; break;
 	case 7: tops->ftype = test_ftype[ctr]; break;
 
-	default: cerr << "Test case not recognized, abort" << endl; exit(0);
+	default: cerr << "Test case not recognized, abort" << endl; std::exit(EXIT_FAILURE);
 	}
 }
 
@@ -267,7 +268,7 @@ int main(int argc, char** argv)
 	if(argc != 2)
 	{
 		cout << "Please call with 0 if acting as server or 1 if acting as client" << endl;
-		return 0;
+		return EXIT_FAILURE;
 	}
 
 	//Determines whether the program is executed in the sender or receiver role
@@ -326,7 +327,7 @@ int main(int argc, char** argv)
 	delete crypt;
 	delete glock;
 
-	return 1;
+	return EXIT_SUCCESS;
 }
 
 


### PR DESCRIPTION
An exit code of 1 usually denotes an error. Use `EXIT_SUCCESS`/`EXIT_FAILURE` instead.