### PR TITLE
Fix AES fixed key ALSZ

### DIFF
--- a/ot/alsz-ot-ext-rec.cpp
+++ b/ot/alsz-ot-ext-rec.cpp
@@ -487,7 +487,7 @@ void ALSZOTExtRec::ComputeBaseOTs(field_type ftype) {
 			}*/
 			memcpy(buf, X[0]->GetArr() + secparambytes * m_nBaseOTs * i, secparambytes * m_nBaseOTs);
 			memcpy(buf + secparambytes * m_nBaseOTs, X[1]->GetArr() + secparambytes * m_nBaseOTs * i, secparambytes * m_nBaseOTs);
-			InitAESKey(tmp_keys, buf, nsndvals * m_nBaseOTs, m_cCrypt);
+			InitPRFKeys(tmp_keys, buf, nsndvals * m_nBaseOTs);
 			m_tBaseOTKeys.push_back(tmp_keys);
 		}
 

--- a/ot/alsz-ot-ext-snd.cpp
+++ b/ot/alsz-ot-ext-snd.cpp
@@ -507,7 +507,7 @@ void ALSZOTExtSnd::ComputeBaseOTs(field_type ftype) {
 			//tmp->choices->SetBits(U.GetArr(), (uint64_t) i * m_nBaseOTs, (uint64_t) m_nBaseOTs);
 			tmp_keys = (OT_AES_KEY_CTX*) malloc(sizeof(OT_AES_KEY_CTX) * m_nBaseOTs);
 
-			InitAESKey(tmp_keys, resp.GetArr()+i*m_nBaseOTs*secparambytes, m_nBaseOTs, m_cCrypt);
+			InitPRFKeys(tmp_keys, resp.GetArr() + i * m_nBaseOTs * secparambytes, m_nBaseOTs);
 			m_tBaseOTKeys.push_back(tmp_keys);
 
 		}


### PR DESCRIPTION
Fixed a bug which caused the ALSZ OTExtension routine to fail if fixed keys were used